### PR TITLE
Potential fix for code scanning alert no. 6: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/app.go
+++ b/app.go
@@ -814,6 +814,12 @@ func (a *App) extractFFmpeg(zipPath, destDir string) error {
 				return err
 			}
 
+			// Validate archive entry name to prevent directory traversal / Zip Slip
+			if strings.Contains(f.Name, "..") || filepath.IsAbs(f.Name) {
+				rc.Close()
+				continue
+			}
+
 			destPath := filepath.Join(destDir, filepath.Base(f.Name))
 			out, err := os.Create(destPath)
 			if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/Aswanidev-vs/Predator/security/code-scanning/6](https://github.com/Aswanidev-vs/Predator/security/code-scanning/6)

General fix: Before using an archive entry’s name to construct a filesystem path, validate that it does not contain any directory traversal components (`..`), absolute paths, or other unexpected elements. You can normalize the path and ensure it remains within the intended destination directory, or more simply, reject any entry whose name contains `..` or is an absolute path.

Best fix here without changing existing functionality: the code already uses `filepath.Base(f.Name)` so the effective written filename is the basename (e.g., `ffmpeg.exe`). To make the trust boundary explicit and satisfy the Zip Slip recommendation, we can add a small validation just before constructing `destPath`. We’ll check:

- Reject any entry whose `f.Name` contains `..` as a segment (`strings.Contains(f.Name, "..")` is enough for this narrow use).
- Optionally, also reject absolute paths: `filepath.IsAbs(f.Name)`.

If the entry fails validation, we `continue` and skip that file. This keeps behavior for normal archives unchanged (they don’t use `..` or absolute paths for `ffmpeg`/`ffprobe`), while hardening against malicious zips.

Concretely in `app.go`:

- In the loop starting at line 799, just before `destPath := filepath.Join(destDir, filepath.Base(f.Name))`, insert a guard:

  ```go
  if strings.Contains(f.Name, "..") || filepath.IsAbs(f.Name) {
      rc.Close()
      continue
  }
  ```

- No new imports are needed; `strings` and `filepath` are already imported.
- This guard ensures that tainted `f.Name` containing traversal is never used to construct `destPath` or passed to `os.Create`/`os.Chmod`, addressing all alert variants.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a security vulnerability in archive extraction that could allow malicious archives to write files outside their intended directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->