### PR TITLE
Potential fix for code scanning alert no. 8: Missing regular expression anchor

### DIFF
--- a/app.go
+++ b/app.go
@@ -1150,21 +1150,21 @@ func extractVideoID(url string) string {
 	}
 
 	// Try to extract from instagram.com/p/SHORTCODE
-	re4 := regexp.MustCompile(`instagram\.com/p/([a-zA-Z0-9_-]+)`)
-	if matches := re4.FindStringSubmatch(url); len(matches) > 1 {
-		return "ig_" + matches[1]
+	re4 := regexp.MustCompile(`^https?://(www\.)?instagram\.com/p/([a-zA-Z0-9_-]+)`)
+	if matches := re4.FindStringSubmatch(url); len(matches) > 2 {
+		return "ig_" + matches[2]
 	}
 
 	// Try to extract from instagram.com/reel/SHORTCODE
-	re5 := regexp.MustCompile(`instagram\.com/reel/([a-zA-Z0-9_-]+)`)
-	if matches := re5.FindStringSubmatch(url); len(matches) > 1 {
-		return "ig_" + matches[1]
+	re5 := regexp.MustCompile(`^https?://(www\.)?instagram\.com/reel/([a-zA-Z0-9_-]+)`)
+	if matches := re5.FindStringSubmatch(url); len(matches) > 2 {
+		return "ig_" + matches[2]
 	}
 
 	// Try to extract from instagram.com/reels/SHORTCODE
-	re6 := regexp.MustCompile(`instagram\.com/reels/([a-zA-Z0-9_-]+)`)
-	if matches := re6.FindStringSubmatch(url); len(matches) > 1 {
-		return "ig_" + matches[1]
+	re6 := regexp.MustCompile(`^https?://(www\.)?instagram\.com/reels/([a-zA-Z0-9_-]+)`)
+	if matches := re6.FindStringSubmatch(url); len(matches) > 2 {
+		return "ig_" + matches[2]
 	}
 
 	return ""


### PR DESCRIPTION
Potential fix for [https://github.com/Aswanidev-vs/Predator/security/code-scanning/8](https://github.com/Aswanidev-vs/Predator/security/code-scanning/8)

In general, to fix this issue you should anchor the regular expression so it matches the expected position within the URL rather than any substring. For full URLs this typically means requiring the scheme, optional `www.`, and the expected host at the beginning (`^https?://(www\.)?instagram\.com/...`). This prevents URLs from other hosts that merely contain an Instagram URL fragment from being treated as valid.

For this specific code, the best fix is to update all the Instagram-related regexes (`re4`, `re5`, `re6`) to (a) anchor at the start of the string and (b) include the URL scheme and optional `www.` prefix, so they only match real Instagram URLs like `https://instagram.com/reel/ID` or `http://www.instagram.com/p/ID`. The YouTube patterns already rely on recognizable path segments but also are unanchored; however, CodeQL is complaining specifically about the Instagram one. To keep behavior consistent across Instagram patterns while not changing their fundamental purpose, we will update all three Instagram regexes:

- `re4` from ``instagram\.com/p/([a-zA-Z0-9_-]+)`` to `^https?://(www\.)?instagram\.com/p/([a-zA-Z0-9_-]+)`
- `re5` from ``instagram\.com/reel/([a-zA-Z0-9_-]+)`` to `^https?://(www\.)?instagram\.com/reel/([a-zA-Z0-9_-]+)`
- `re6` from ``instagram\.com/reels/([a-zA-Z0-9_-]+)`` to `^https?://(www\.)?instagram\.com/reels/([a-zA-Z0-9_-]+)`

No new imports or helper methods are needed; we only adjust the pattern strings in `app.go` within `extractVideoID`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
