### PR TITLE
Potential fix for code scanning alert no. 6: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/app.go
+++ b/app.go
@@ -923,12 +923,20 @@ func (a *App) extractFFmpeg(zipPath, destDir string) error {
 				continue
 			}
 
+			// Derive a safe base name from the archive entry and validate it
+			baseName := filepath.Base(f.Name)
+			if baseName == "" || baseName == "." || baseName == ".." || strings.Contains(baseName, "..") ||
+				strings.Contains(baseName, string(os.PathSeparator)) || strings.Contains(baseName, "/") {
+				// Skip potentially unsafe or malicious paths
+				continue
+			}
+
 			rc, err := f.Open()
 			if err != nil {
 				return err
 			}
 
-			destPath := filepath.Join(destDir, filepath.Base(f.Name))
+			destPath := filepath.Join(destDir, baseName)
 			out, err := os.Create(destPath)
 			if err != nil {
 				rc.Close()


### PR DESCRIPTION
Potential fix for [https://github.com/Aswanidev-vs/Predator/security/code-scanning/6](https://github.com/Aswanidev-vs/Predator/security/code-scanning/6)

In general, to fix Zip Slip–style issues, you must ensure that any path derived from archive entry names cannot escape the intended destination. Common approaches are: (1) reject any entry whose path contains `..` components or is absolute, and/or (2) derive a safe name (e.g., via `filepath.Base`) and verify that it does not contain path separators or `..` before using it in file operations.

For this specific code, the safest minimal change that preserves functionality is:

- Keep using `filepath.Base(f.Name)` to discard any directory components.
- Introduce a new variable, e.g., `baseName := filepath.Base(f.Name)`.
- Validate `baseName`:
  - Ensure it is not empty and not `"."` or `".."`.
  - Ensure it does not contain any path separators (`/` or OS-specific separator) or `..`.
- Only proceed with creating and writing the file (and `Chmod`) if the base name passes these checks.
- Construct `destPath` using only this validated `baseName`.

This avoids changing behavior for normal, valid entries (they still extract to `destDir/<basename>`), while preventing crafted names from being used and satisfying the static analysis requirement that archive entry data be sanitized before file-system operations.

Concretely, within `app.go` around lines 913–951, we will:

- Add a `baseName` variable from `filepath.Base(f.Name)`.
- Add a small validation `if` that `continue`s the loop if `baseName` is unsafe.
- Use `baseName` in `filepath.Join(destDir, baseName)` instead of calling `filepath.Base` inline.

No new imports are necessary; `path/filepath` and `strings` are already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive extraction safety by adding validation for entry names to prevent processing of entries with invalid or unsafe paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->