### PR TITLE
Potential fix for code scanning alert no. 10: Missing regular expression anchor

### DIFF
--- a/app.go
+++ b/app.go
@@ -651,7 +651,7 @@ var (
 	reExtractRes        = regexp.MustCompile(`^(\d+)p`)
 	reVideoIDQuery      = regexp.MustCompile(`[?&]v=([a-zA-Z0-9_-]{11})`)
 	reVideoIDShort      = regexp.MustCompile(`youtu\.be/([a-zA-Z0-9_-]{11})`)
-	reVideoIDShorts     = regexp.MustCompile(`youtube\.com/shorts/([a-zA-Z0-9_-]{11})`)
+	reVideoIDShorts     = regexp.MustCompile(`^https?://(www\.)?youtube\.com/shorts/([a-zA-Z0-9_-]{11})(?:[/?#].*)?$`)
 	reVideoIDInstaPost  = regexp.MustCompile(`^https?://(www\.)?instagram\.com/p/([a-zA-Z0-9_-]+)`)
 	reVideoIDInstaReel  = regexp.MustCompile(`^https?://(www\.)?instagram\.com/reel/([a-zA-Z0-9_-]+)`)
 	reVideoIDInstaReels = regexp.MustCompile(`^https?://(www\.)?instagram\.com/reels/([a-zA-Z0-9_-]+)`)


### PR DESCRIPTION
Potential fix for [https://github.com/Aswanidev-vs/Predator/security/code-scanning/10](https://github.com/Aswanidev-vs/Predator/security/code-scanning/10)

Use start/end anchors and an explicit URL structure so the pattern only matches valid YouTube Shorts URLs, not arbitrary strings containing `youtube.com/shorts/...` somewhere inside.

Best fix in `app.go` is to replace line 654’s regex with an anchored expression similar to the Instagram ones:
- require scheme: `https?://`
- optional `www.`
- exact host `youtube.com`
- exact path prefix `/shorts/`
- capture exactly the 11-char video ID
- optionally allow trailing query/fragment/path suffix if needed, while still preventing prefix host confusion

A safe and functionality-preserving option is:
`^https?://(www\.)?youtube\.com/shorts/([a-zA-Z0-9_-]{11})(?:[/?#].*)?$`

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube Shorts URL detection to reliably handle various URL formats, including those with or without protocol prefixes, www subdomain, and trailing paths or query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->