### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/submodule-check.yml
+++ b/.github/workflows/submodule-check.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   verify-submodules:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Aswanidev-vs/Predator/security/code-scanning/11](https://github.com/Aswanidev-vs/Predator/security/code-scanning/11)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged.

Best fix here: define workflow-level permissions directly under `on:` (or before `jobs:`) with:

- `contents: read`

This preserves existing functionality because this workflow only needs to read repository contents for checkout and git status checks. No new imports, methods, or dependencies are needed.

Change location: `.github/workflows/submodule-check.yml`, between the trigger section and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
